### PR TITLE
Address code review comments

### DIFF
--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientCookieMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientCookieMiddleware.java
@@ -48,13 +48,19 @@ public class ClientCookieMiddleware implements FlightClientMiddleware {
    * Factory used within FlightClient.
    */
   public static class Factory implements FlightClientMiddleware.Factory {
+    public ClientCookieMiddleware getClientCookieMiddleware() {
+      return clientCookieMiddleware;
+    }
+
+    private ClientCookieMiddleware clientCookieMiddleware;
     // Use a map to track the most recent version of a cookie from the server.
     // Note that cookie names are case-sensitive (but header names aren't).
     private ConcurrentMap<String, HttpCookie> cookies = new ConcurrentHashMap<>();
 
     @Override
     public ClientCookieMiddleware onCallStarted(CallInfo info) {
-      return new ClientCookieMiddleware(this);
+      this.clientCookieMiddleware = new ClientCookieMiddleware(this);
+      return this.clientCookieMiddleware;
     }
   }
 
@@ -79,9 +85,7 @@ public class ClientCookieMiddleware implements FlightClientMiddleware {
     };
     final Iterable<String> setCookieHeaders = incomingHeaders.getAll(SET_COOKIE_HEADER);
     if (setCookieHeaders != null) {
-      for (String cookieHeader : setCookieHeaders) {
-        handleSetCookieHeader.accept(cookieHeader);
-      }
+      setCookieHeaders.forEach(handleSetCookieHeader);
     }
   }
 

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientCookieMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientCookieMiddleware.java
@@ -40,7 +40,8 @@ public class ClientCookieMiddleware implements FlightClientMiddleware {
   private static final String COOKIE_HEADER = "Cookie";
   private final Factory factory;
 
-  public ClientCookieMiddleware(Factory factory) {
+  @VisibleForTesting
+  ClientCookieMiddleware(Factory factory) {
     this.factory = factory;
   }
 
@@ -48,19 +49,13 @@ public class ClientCookieMiddleware implements FlightClientMiddleware {
    * Factory used within FlightClient.
    */
   public static class Factory implements FlightClientMiddleware.Factory {
-    public ClientCookieMiddleware getClientCookieMiddleware() {
-      return clientCookieMiddleware;
-    }
-
-    private ClientCookieMiddleware clientCookieMiddleware;
     // Use a map to track the most recent version of a cookie from the server.
     // Note that cookie names are case-sensitive (but header names aren't).
     private ConcurrentMap<String, HttpCookie> cookies = new ConcurrentHashMap<>();
 
     @Override
     public ClientCookieMiddleware onCallStarted(CallInfo info) {
-      this.clientCookieMiddleware = new ClientCookieMiddleware(this);
-      return this.clientCookieMiddleware;
+      return new ClientCookieMiddleware(this);
     }
   }
 

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/TestCookieHandling.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/TestCookieHandling.java
@@ -17,10 +17,26 @@
 
 package org.apache.arrow.flight.client;
 
+import java.io.IOException;
+
 import org.apache.arrow.flight.CallHeaders;
+import org.apache.arrow.flight.CallInfo;
+import org.apache.arrow.flight.CallStatus;
+import org.apache.arrow.flight.Criteria;
 import org.apache.arrow.flight.ErrorFlightMetadata;
+import org.apache.arrow.flight.FlightClient;
+import org.apache.arrow.flight.FlightInfo;
+import org.apache.arrow.flight.FlightProducer;
+import org.apache.arrow.flight.FlightServer;
+import org.apache.arrow.flight.FlightServerMiddleware;
+import org.apache.arrow.flight.FlightTestUtil;
+import org.apache.arrow.flight.NoOpFlightProducer;
+import org.apache.arrow.flight.RequestContext;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -29,13 +45,23 @@ import org.junit.Test;
  */
 public class TestCookieHandling {
   private static final String SET_COOKIE_HEADER = "Set-Cookie";
-  private static final String SET_COOKIE2_HEADER = "Set-Cookie2";
+  private static final String COOKIE_HEADER = "Cookie";
+  private BufferAllocator allocator;
+  private FlightServer server;
+  private FlightClient client;
 
-  private ClientCookieMiddleware cookieMiddleware = new ClientCookieMiddleware();
+  private ClientCookieMiddleware.Factory factory = new ClientCookieMiddleware.Factory();
+  private ClientCookieMiddleware cookieMiddleware = new ClientCookieMiddleware(factory);
+
+  @Before
+  public void setup() throws Exception {
+    allocator = new RootAllocator(Long.MAX_VALUE);
+    startServerAndClient();
+  }
 
   @After
   public void cleanup() {
-    cookieMiddleware = new ClientCookieMiddleware();
+    cookieMiddleware = new ClientCookieMiddleware(factory);
   }
 
   @Test
@@ -43,7 +69,7 @@ public class TestCookieHandling {
     CallHeaders headersToSend = new ErrorFlightMetadata();
     headersToSend.insert(SET_COOKIE_HEADER, "k=v");
     cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("k=v", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=v", cookieMiddleware.getValidCookiesAsString());
   }
 
   @Test
@@ -51,15 +77,15 @@ public class TestCookieHandling {
     CallHeaders headersToSend = new ErrorFlightMetadata();
     headersToSend.insert(SET_COOKIE_HEADER, "k=v");
     cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("k=v", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=v", cookieMiddleware.getValidCookiesAsString());
 
     headersToSend = new ErrorFlightMetadata();
     cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("k=v", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=v", cookieMiddleware.getValidCookiesAsString());
 
     headersToSend = new ErrorFlightMetadata();
     cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("k=v", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=v", cookieMiddleware.getValidCookiesAsString());
   }
 
   @Test
@@ -68,11 +94,11 @@ public class TestCookieHandling {
     headersToSend.insert(SET_COOKIE_HEADER, "k=v; Max-Age=2");
     cookieMiddleware.onHeadersReceived(headersToSend);
     // Note: using max-age changes cookie version from 0->1, which quotes values.
-    Assert.assertEquals("k=\"v\"", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=\"v\"", cookieMiddleware.getValidCookiesAsString());
 
     headersToSend = new ErrorFlightMetadata();
     cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("k=\"v\"", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=\"v\"", cookieMiddleware.getValidCookiesAsString());
 
     try {
       Thread.sleep(5000);
@@ -80,7 +106,7 @@ public class TestCookieHandling {
     }
 
     // Verify that the k cookie was discarded because it expired.
-    Assert.assertTrue(cookieMiddleware.calculateCookieString().isEmpty());
+    Assert.assertTrue(cookieMiddleware.getValidCookiesAsString().isEmpty());
   }
 
   @Test
@@ -89,14 +115,14 @@ public class TestCookieHandling {
     headersToSend.insert(SET_COOKIE_HEADER, "k=v; Max-Age=2");
     cookieMiddleware.onHeadersReceived(headersToSend);
     // Note: using max-age changes cookie version from 0->1, which quotes values.
-    Assert.assertEquals("k=\"v\"", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=\"v\"", cookieMiddleware.getValidCookiesAsString());
 
     headersToSend = new ErrorFlightMetadata();
     headersToSend.insert(SET_COOKIE_HEADER, "k=v; Max-Age=-2");
     cookieMiddleware.onHeadersReceived(headersToSend);
 
     // Verify that the k cookie was discarded because the server told the client it is expired.
-    Assert.assertTrue(cookieMiddleware.calculateCookieString().isEmpty());
+    Assert.assertTrue(cookieMiddleware.getValidCookiesAsString().isEmpty());
   }
 
   @Ignore
@@ -106,7 +132,7 @@ public class TestCookieHandling {
     headersToSend.insert(SET_COOKIE_HEADER, "k=v; Max-Age=2");
     cookieMiddleware.onHeadersReceived(headersToSend);
     // Note: using max-age changes cookie version from 0->1, which quotes values.
-    Assert.assertEquals("k=\"v\"", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=\"v\"", cookieMiddleware.getValidCookiesAsString());
 
     headersToSend = new ErrorFlightMetadata();
 
@@ -116,7 +142,7 @@ public class TestCookieHandling {
     cookieMiddleware.onHeadersReceived(headersToSend);
 
     // Verify that the k cookie was discarded because the server told the client it is expired.
-    Assert.assertTrue(cookieMiddleware.calculateCookieString().isEmpty());
+    Assert.assertTrue(cookieMiddleware.getValidCookiesAsString().isEmpty());
   }
 
   @Test
@@ -124,12 +150,12 @@ public class TestCookieHandling {
     CallHeaders headersToSend = new ErrorFlightMetadata();
     headersToSend.insert(SET_COOKIE_HEADER, "k=v");
     cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("k=v", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=v", cookieMiddleware.getValidCookiesAsString());
 
     headersToSend = new ErrorFlightMetadata();
     headersToSend.insert(SET_COOKIE_HEADER, "k=v2");
     cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("k=v2", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=v2", cookieMiddleware.getValidCookiesAsString());
   }
 
   @Test
@@ -138,27 +164,75 @@ public class TestCookieHandling {
     headersToSend.insert(SET_COOKIE_HEADER, "firstKey=firstVal");
     headersToSend.insert(SET_COOKIE_HEADER, "secondKey=secondVal");
     cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("firstKey=firstVal; secondKey=secondVal", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("firstKey=firstVal; secondKey=secondVal", cookieMiddleware.getValidCookiesAsString());
   }
 
   @Test
-  public void basicCookiesWithSetCookie2() {
-    CallHeaders headersToSend = new ErrorFlightMetadata();
-    headersToSend.insert(SET_COOKIE2_HEADER, "firstKey=firstVal");
-    cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("firstKey=firstVal", cookieMiddleware.calculateCookieString());
+  public void cookieStaysAfterMultipleRequestsEndToEnd() {
+    client.handshake();
+    Assert.assertEquals("k=v", cookieMiddleware.getValidCookiesAsString());
+    client.listFlights(Criteria.ALL);
+    Assert.assertEquals("k=v", cookieMiddleware.getValidCookiesAsString());
+    client.listFlights(Criteria.ALL);
+    Assert.assertEquals("k=v", cookieMiddleware.getValidCookiesAsString());
   }
 
-  @Ignore
-  @Test
-  public void multipleCookiesWithSetCookie2() {
-    // There seems to be a JDK bug with HttpCookie.parse() with multiple cookies
-    // in a Set-Cookie2 header. This is odd, because that method explictly returns a list
-    // of cookies because of Set-Cookie2.
-    // Set-Cookie2 itself is deprecated.
-    CallHeaders headersToSend = new ErrorFlightMetadata();
-    headersToSend.insert(SET_COOKIE2_HEADER, "firstKey=firstVal, secondKey=secondVal");
-    cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("firstKey=firstVal; secondKey=secondVal", cookieMiddleware.calculateCookieString());
+  /**
+   * A server middleware component that injects SET_COOKIE_HEADER into the outgoing headers.
+   */
+  static class SetCookieHeaderInjector implements FlightServerMiddleware {
+    private final Factory factory;
+
+    public SetCookieHeaderInjector(Factory factory) {
+      this.factory = factory;
+    }
+
+    @Override
+    public void onBeforeSendingHeaders(CallHeaders outgoingHeaders) {
+      if (!factory.receivedCookieHeader) {
+        outgoingHeaders.insert(SET_COOKIE_HEADER, "k=v");
+      }
+    }
+
+    @Override
+    public void onCallCompleted(CallStatus status) {
+
+    }
+
+    @Override
+    public void onCallErrored(Throwable err) {
+
+    }
+
+    static class Factory implements FlightServerMiddleware.Factory<SetCookieHeaderInjector> {
+      private boolean receivedCookieHeader = false;
+
+      @Override
+      public SetCookieHeaderInjector onCallStarted(CallInfo info, CallHeaders incomingHeaders,
+                                                   RequestContext context) {
+        if (null != incomingHeaders.get(COOKIE_HEADER)) {
+          receivedCookieHeader = true;
+        }
+        return new SetCookieHeaderInjector(this);
+      }
+    }
+  }
+
+  private void startServerAndClient() throws IOException {
+    final FlightProducer flightProducer = new NoOpFlightProducer() {
+      public void listFlights(CallContext context, Criteria criteria,
+                              StreamListener<FlightInfo> listener) {
+        listener.onCompleted();
+      }
+    };
+
+    this.server = FlightTestUtil.getStartedServer((location) -> FlightServer
+            .builder(allocator, location, flightProducer)
+            .middleware(FlightServerMiddleware.Key.of("test"), new SetCookieHeaderInjector.Factory())
+            .build());
+
+    this.client = FlightClient.builder(allocator, server.getLocation())
+            .intercept(factory)
+            .build();
   }
 }


### PR DESCRIPTION
- Remove COOKIE2_HEADER
- Store cookies in the concurrent hashmap in the factory for persistance.
- Added end to end test for cookie persistence